### PR TITLE
Feature(#1): REST Docs + Swagger 설정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("org.springframework.boot") version "3.5.3"
     id("io.spring.dependency-management") version "1.1.7"
     id("org.asciidoctor.jvm.convert") version "3.3.2"
+    id("com.epages.restdocs-api-spec") version "0.19.4"
 }
 
 group = "com.nexters"
@@ -37,6 +38,10 @@ dependencies {
 
     // spring validation
     implementation("org.springframework.boot:spring-boot-starter-validation")
+
+    // restdocs-api-spec
+    testImplementation("com.epages:restdocs-api-spec-mockmvc:0.19.4")
+    testImplementation("org.springframework.restdocs:spring-restdocs-mockmvc")
 }
 
 tasks.withType<Test> {
@@ -47,7 +52,10 @@ tasks.test {
     outputs.dir(project.extra["snippetsDir"]!!)
 }
 
-tasks.asciidoctor {
-    inputs.dir(project.extra["snippetsDir"]!!)
-    dependsOn(tasks.test)
+openapi3 {
+    title = "Gamchi API"
+    description = "Swagger Docs"
+    version = "0.0.1"
+    format = "yaml"
+    outputFileNamePrefix = "openapi3"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,9 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.restdocs:spring-restdocs-mockmvc")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+    // spring validation
+    implementation("org.springframework.boot:spring-boot-starter-validation")
 }
 
 tasks.withType<Test> {

--- a/src/main/java/com/nexters/teamace/chat/presentation/ChatController.java
+++ b/src/main/java/com/nexters/teamace/chat/presentation/ChatController.java
@@ -1,0 +1,21 @@
+package com.nexters.teamace.chat.presentation;
+
+import com.nexters.teamace.common.presentation.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/chats")
+public class ChatController {
+
+  @PostMapping
+  public ApiResponse<ChatResponse> createChat(@RequestBody @Valid final ChatRequest request) {
+    return ApiResponse.success(new ChatResponse(1L));
+  }
+}

--- a/src/main/java/com/nexters/teamace/chat/presentation/ChatRequest.java
+++ b/src/main/java/com/nexters/teamace/chat/presentation/ChatRequest.java
@@ -1,0 +1,5 @@
+package com.nexters.teamace.chat.presentation;
+
+public record ChatRequest(String userId) {
+
+}

--- a/src/main/java/com/nexters/teamace/chat/presentation/ChatResponse.java
+++ b/src/main/java/com/nexters/teamace/chat/presentation/ChatResponse.java
@@ -1,0 +1,5 @@
+package com.nexters.teamace.chat.presentation;
+
+public record ChatResponse(Long chatId) {
+
+}

--- a/src/main/java/com/nexters/teamace/common/presentation/ApiResponse.java
+++ b/src/main/java/com/nexters/teamace/common/presentation/ApiResponse.java
@@ -1,0 +1,16 @@
+package com.nexters.teamace.common.presentation;
+
+public record ApiResponse<T>(
+        boolean success,
+        T data,
+        ErrorMessage error
+) {
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(true, data, null);
+    }
+
+    public static <T> ApiResponse<T> error(String code, String message) {
+        return new ApiResponse<>(false, null, new ErrorMessage(code, message));
+    }
+}

--- a/src/main/java/com/nexters/teamace/common/presentation/ErrorMessage.java
+++ b/src/main/java/com/nexters/teamace/common/presentation/ErrorMessage.java
@@ -1,0 +1,20 @@
+package com.nexters.teamace.common.presentation;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+public record ErrorMessage(
+    String code,
+    String message,
+    Map<String, String> details,
+    LocalDateTime timestamp
+) {
+    
+    public ErrorMessage(String code, String message) {
+        this(code, message, null, LocalDateTime.now());
+    }
+    
+    public ErrorMessage(String code, String message, Map<String, String> details) {
+        this(code, message, details, LocalDateTime.now());
+    }
+}

--- a/src/test/java/com/nexters/teamace/chat/presentation/ChatControllerTest.java
+++ b/src/test/java/com/nexters/teamace/chat/presentation/ChatControllerTest.java
@@ -1,0 +1,75 @@
+package com.nexters.teamace.chat.presentation;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static com.epages.restdocs.apispec.Schema.schema;
+import static org.hamcrest.Matchers.equalTo;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.nexters.teamace.common.utils.ControllerTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.ResultActions;
+
+class ChatControllerTest extends ControllerTest {
+
+  @Test
+  @DisplayName("채팅을 생성할 수 있다")
+  void createChat() throws Exception {
+    // given
+    final ChatRequest request = new ChatRequest("user123");
+    final String requestBody = objectMapper.writeValueAsString(request);
+    final ChatResponse response = new ChatResponse(1L);
+
+    // when
+    final ResultActions resultActions = mockMvc.perform(
+        post("/api/v1/chats")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(requestBody));
+
+    // then
+    resultActions
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.data", equalTo(asParsedJson(response))))
+        .andExpect(jsonPath("$.error").doesNotExist())
+        .andDo(
+            MockMvcRestDocumentationWrapper.document(
+                "{class_name}/{method_name}",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                resource(
+                    ResourceSnippetParameters.builder()
+                        .tag("Chat")
+                        .description("채팅 생성")
+                        .requestFields(
+                            fieldWithPath("userId")
+                                .type(JsonFieldType.STRING)
+                                .description("사용자 ID"))
+                        .responseFields(
+                            fieldWithPath("success")
+                                .type(JsonFieldType.BOOLEAN)
+                                .description("성공 여부"),
+                            fieldWithPath("data")
+                                .type(JsonFieldType.OBJECT)
+                                .description("응답 데이터"),
+                            fieldWithPath("data.chatId")
+                                .type(JsonFieldType.NUMBER)
+                                .description("생성된 채팅 ID"),
+                            fieldWithPath("error")
+                                .type(JsonFieldType.NULL)
+                                .description("에러 정보 (성공 시 null)"))
+                        .requestSchema(schema("ChatRequest"))
+                        .responseSchema(schema("ChatResponse"))
+                        .build())));
+  }
+}

--- a/src/test/java/com/nexters/teamace/common/utils/ControllerTest.java
+++ b/src/test/java/com/nexters/teamace/common/utils/ControllerTest.java
@@ -1,0 +1,22 @@
+package com.nexters.teamace.common.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest
+@AutoConfigureRestDocs
+public abstract class ControllerTest {
+
+  @Autowired protected MockMvc mockMvc;
+  @Autowired protected ObjectMapper objectMapper;
+
+  protected Object asParsedJson(Object obj) throws JsonProcessingException {
+    String json = objectMapper.writeValueAsString(obj);
+    return JsonPath.read(json, "$");
+  }
+}


### PR DESCRIPTION
## 작업 개요

- 이슈: #1 
- REST Docs로 Swagger 문서를 생성할 수 있는 기능을 설정한다.

## 작업 사항

- Swagger yaml 파일 생성하는 코드 작성
- sample contoller 작성
- sample REST Docs 작성

## 스크린샷

<img width="1525" height="678" alt="image" src="https://github.com/user-attachments/assets/1d0d79ee-b246-4b91-b023-9aeba38a10ba" />

