### PR TITLE
Feature(#21): Swagger UI workflows

### DIFF
--- a/.github/workflows/deploy-swagger.yml
+++ b/.github/workflows/deploy-swagger.yml
@@ -1,0 +1,76 @@
+name: Deploy Swagger UI
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  generate-openapi:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 24
+        uses: actions/setup-java@v4
+        with:
+          java-version: '24'
+          distribution: 'oracle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Generate OpenAPI documentation
+        run: ./gradlew openapi3
+
+      - name: Copy OpenAPI files to server
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USERNAME }}
+          password: ${{ secrets.SERVER_PASSWORD }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          source: "build/api-spec/openapi3.yaml"
+          target: "~/app/docs"
+          strip_components: 2
+          overwrite: true
+
+  deploy:
+    needs: generate-openapi
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy Swagger UI
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USERNAME }}
+          password: ${{ secrets.SERVER_PASSWORD }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script: |
+            # Check if container is already running
+            if docker ps --format '{{.Names}}' | grep -q '^team-ace-swagger$'; then
+              echo "✅ Swagger UI container is already running. Skipping deployment."
+              exit 0
+            fi
+            
+            # Remove stopped container if exists
+            docker rm team-ace-swagger 2>/dev/null || true
+            
+            echo "🚀 Starting Swagger UI container..."
+            # Run Swagger UI container
+            docker run -d \
+              --name team-ace-swagger \
+              --restart unless-stopped \
+              -p 8081:8080 \
+              -e SWAGGER_JSON=/app/openapi3.yaml \
+              -e FILTER=true \
+              -e TRY_IT_OUT_ENABLED=true \
+              -v ~/app/docs/openapi3.yaml:/app/openapi3.yaml:ro \
+              swaggerapi/swagger-ui:latest
+            
+            echo "✅ Swagger UI container started successfully!"


### PR DESCRIPTION
## 📌 관련 이슈

closes #21 

## 📝 작업 개요

- Swagger 배포 파이프라인 구성
- NCloud ACG에서 본인 IP 확인 후, 해당 IP의 8081 포트의 Inbound를 열어주고, `http://{host}:8081`로 접속하면 SwaggerUI 확인 가능

## ✅ 작업 사항

- [x] Swagger 문서 및 UI 배포 GithubActions Workflow 작성

## 📸 스크린샷(필수 X)

<img width="1172" height="943" alt="image" src="https://github.com/user-attachments/assets/2b38bd5b-8e3d-4007-bd85-2355cee23324" />

