### PR TITLE
Feature/35 요정 API 구현

### DIFF
--- a/src/main/java/com/nexters/teamace/auth/presentation/AuthUserArgumentResolver.java
+++ b/src/main/java/com/nexters/teamace/auth/presentation/AuthUserArgumentResolver.java
@@ -1,0 +1,46 @@
+package com.nexters.teamace.auth.presentation;
+
+import com.nexters.teamace.common.presentation.AuthUser;
+import com.nexters.teamace.user.application.GetUserResult;
+import com.nexters.teamace.user.application.UserService;
+import com.nexters.teamace.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final UserService userService;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(AuthUser.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+            @NotNull MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            @NotNull NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory)
+            throws Exception {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+        if (!(principal instanceof UserDetails userDetails)) {
+            throw new IllegalArgumentException(
+                    "Invalid principal type: " + principal.getClass().getName());
+        }
+
+        GetUserResult userResult = userService.getUserByUsername(userDetails.getUsername());
+        return new User(userResult.id(), userResult.username(), userResult.nickname());
+    }
+}

--- a/src/main/java/com/nexters/teamace/common/config/WebConfig.java
+++ b/src/main/java/com/nexters/teamace/common/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.nexters.teamace.common.config;
+
+import com.nexters.teamace.auth.presentation.AuthUserArgumentResolver;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthUserArgumentResolver authUserArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authUserArgumentResolver);
+    }
+}

--- a/src/main/java/com/nexters/teamace/common/presentation/AuthUser.java
+++ b/src/main/java/com/nexters/teamace/common/presentation/AuthUser.java
@@ -1,0 +1,10 @@
+package com.nexters.teamace.common.presentation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthUser {}

--- a/src/main/java/com/nexters/teamace/conversation/domain/EmotionSelectConversation.java
+++ b/src/main/java/com/nexters/teamace/conversation/domain/EmotionSelectConversation.java
@@ -2,7 +2,7 @@ package com.nexters.teamace.conversation.domain;
 
 import java.util.List;
 
-public record EmotionSelectConversation(List<MessageConversation> emotions) {
+public record EmotionSelectConversation(List<Emotions> emotions) {
 
     public record Emotions(String name, int score) {}
 }

--- a/src/main/java/com/nexters/teamace/emotion/application/EmotionService.java
+++ b/src/main/java/com/nexters/teamace/emotion/application/EmotionService.java
@@ -1,0 +1,17 @@
+package com.nexters.teamace.emotion.application;
+
+import com.nexters.teamace.emotion.domain.Emotion;
+import com.nexters.teamace.emotion.domain.EmotionRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EmotionService {
+    private final EmotionRepository emotionRepository;
+
+    public List<Emotion> findAllByNamesIn(List<String> names) {
+        return emotionRepository.findAllByNamesIn(names);
+    }
+}

--- a/src/main/java/com/nexters/teamace/emotion/domain/Emotion.java
+++ b/src/main/java/com/nexters/teamace/emotion/domain/Emotion.java
@@ -1,0 +1,25 @@
+package com.nexters.teamace.emotion.domain;
+
+import static lombok.AccessLevel.PROTECTED;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = PROTECTED)
+public class Emotion {
+
+    @Getter private Long id;
+    @Getter private String name;
+    @Getter private String description;
+
+    public Emotion(final String name, final String description) {
+        this.name = name;
+        this.description = description;
+    }
+
+    public Emotion(final Long id, final String name, final String description) {
+        this.id = id;
+        this.name = name;
+        this.description = description;
+    }
+}

--- a/src/main/java/com/nexters/teamace/emotion/domain/EmotionRepository.java
+++ b/src/main/java/com/nexters/teamace/emotion/domain/EmotionRepository.java
@@ -1,0 +1,7 @@
+package com.nexters.teamace.emotion.domain;
+
+import java.util.List;
+
+public interface EmotionRepository {
+    List<Emotion> findAllByNamesIn(List<String> names);
+}

--- a/src/main/java/com/nexters/teamace/emotion/infrastructure/EmotionEntity.java
+++ b/src/main/java/com/nexters/teamace/emotion/infrastructure/EmotionEntity.java
@@ -1,0 +1,32 @@
+package com.nexters.teamace.emotion.infrastructure;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "emotion")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EmotionEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "emotion_id")
+    private Long id;
+
+    private String name;
+
+    private String description;
+
+    public EmotionEntity(String name, String description) {
+        this.name = name;
+        this.description = description;
+    }
+}

--- a/src/main/java/com/nexters/teamace/emotion/infrastructure/EmotionJpaRepository.java
+++ b/src/main/java/com/nexters/teamace/emotion/infrastructure/EmotionJpaRepository.java
@@ -1,0 +1,8 @@
+package com.nexters.teamace.emotion.infrastructure;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmotionJpaRepository extends JpaRepository<EmotionEntity, Long> {
+    List<EmotionEntity> findAllByNameIn(List<String> names);
+}

--- a/src/main/java/com/nexters/teamace/emotion/infrastructure/EmotionRepositoryImpl.java
+++ b/src/main/java/com/nexters/teamace/emotion/infrastructure/EmotionRepositoryImpl.java
@@ -1,0 +1,24 @@
+package com.nexters.teamace.emotion.infrastructure;
+
+import com.nexters.teamace.emotion.domain.Emotion;
+import com.nexters.teamace.emotion.domain.EmotionRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class EmotionRepositoryImpl implements EmotionRepository {
+
+    private final EmotionJpaRepository emotionJpaRepository;
+
+    @Override
+    public List<Emotion> findAllByNamesIn(List<String> names) {
+        return emotionJpaRepository.findAllByNameIn(names).stream()
+                .map(
+                        entity ->
+                                new Emotion(
+                                        entity.getId(), entity.getName(), entity.getDescription()))
+                .toList();
+    }
+}

--- a/src/main/java/com/nexters/teamace/fairy/application/FairyCandidate.java
+++ b/src/main/java/com/nexters/teamace/fairy/application/FairyCandidate.java
@@ -1,0 +1,4 @@
+package com.nexters.teamace.fairy.application;
+
+public record FairyCandidate(
+        Long id, String name, String image, String silhouetteImage, String emotion) {}

--- a/src/main/java/com/nexters/teamace/fairy/application/FairyResult.java
+++ b/src/main/java/com/nexters/teamace/fairy/application/FairyResult.java
@@ -1,0 +1,5 @@
+package com.nexters.teamace.fairy.application;
+
+import java.util.List;
+
+public record FairyResult(List<FairyCandidate> fairies) {}

--- a/src/main/java/com/nexters/teamace/fairy/application/FairyService.java
+++ b/src/main/java/com/nexters/teamace/fairy/application/FairyService.java
@@ -1,0 +1,67 @@
+package com.nexters.teamace.fairy.application;
+
+import com.nexters.teamace.chat.application.ChatRoomService;
+import com.nexters.teamace.conversation.application.ConversationContext;
+import com.nexters.teamace.conversation.application.ConversationService;
+import com.nexters.teamace.conversation.domain.ConversationType;
+import com.nexters.teamace.conversation.domain.EmotionSelectConversation;
+import com.nexters.teamace.emotion.application.EmotionService;
+import com.nexters.teamace.emotion.domain.Emotion;
+import com.nexters.teamace.fairy.domain.Fairy;
+import com.nexters.teamace.fairy.domain.FairyRepository;
+import com.nexters.teamace.user.domain.User;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FairyService {
+
+    private final ConversationService conversationService;
+    private final ChatRoomService chatRoomService;
+    private final EmotionService emotionService;
+    private final FairyRepository fairyRepository;
+
+    public FairyResult getFairy(User user, Long chatRoomId) {
+        /* 1. chatRoomId 기반으로 chatRoom의 모든 질의응답 조회 (TODO)
+         * context 데이터는 아래와 같이 구성해서 던져줄지?
+         * 1. 상담가: 데이터1
+         * 2. 사용자: 데이터2
+         * 3. 상담가: 데이터3
+         * 4. ...
+         * */
+        ConversationType type = ConversationType.EMOTION_ANALYSIS;
+        ConversationContext context = new ConversationContext("질의응답", List.of());
+
+        // 2. 질의응답 기반으로 ai call 해서 감정 후보 획득
+        EmotionSelectConversation emotionSelectConversation =
+                (EmotionSelectConversation)
+                        conversationService.chat(type.getType(), type, context, "");
+
+        // 3. 감정 후보 기반으로 emotion 조회
+        List<Emotion> emotions =
+                emotionService.findAllByNamesIn(
+                        emotionSelectConversation.emotions().stream()
+                                .map(EmotionSelectConversation.Emotions::name)
+                                .toList());
+
+        // 4. emotion 기반으로 fairy 조회 (fairy -> emotion의 단방향 참조를 유지하고 싶다면?)
+        List<Fairy> fairies =
+                fairyRepository.findAllByEmotionIdIn(
+                        emotions.stream().map(Emotion::getId).toList());
+
+        // 5. FairyResult에 맞게 정제하여 반환
+        return new FairyResult(
+                fairies.stream()
+                        .map(
+                                f ->
+                                        new FairyCandidate(
+                                                f.getId(),
+                                                f.getName(),
+                                                f.getImageUrl(),
+                                                f.getSilhouetteImageUrl(),
+                                                f.getEmotion().getName()))
+                        .toList());
+    }
+}

--- a/src/main/java/com/nexters/teamace/fairy/domain/Fairy.java
+++ b/src/main/java/com/nexters/teamace/fairy/domain/Fairy.java
@@ -1,0 +1,42 @@
+package com.nexters.teamace.fairy.domain;
+
+import static lombok.AccessLevel.PROTECTED;
+
+import com.nexters.teamace.emotion.domain.Emotion;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Fairy {
+
+    private Long id;
+    private String name;
+    private String imageUrl;
+    private String silhouetteImageUrl;
+    private Emotion emotion;
+
+    public Fairy(
+            final String name,
+            final String imageUrl,
+            final String silhouetteImageUrl,
+            final Emotion emotion) {
+        this.name = name;
+        this.imageUrl = imageUrl;
+        this.silhouetteImageUrl = silhouetteImageUrl;
+        this.emotion = emotion;
+    }
+
+    public Fairy(
+            final Long id,
+            final String name,
+            final String imageUrl,
+            final String silhouetteImageUrl,
+            final Emotion emotion) {
+        this.id = id;
+        this.name = name;
+        this.imageUrl = imageUrl;
+        this.silhouetteImageUrl = silhouetteImageUrl;
+        this.emotion = emotion;
+    }
+}

--- a/src/main/java/com/nexters/teamace/fairy/domain/FairyRepository.java
+++ b/src/main/java/com/nexters/teamace/fairy/domain/FairyRepository.java
@@ -1,0 +1,12 @@
+package com.nexters.teamace.fairy.domain;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FairyRepository {
+    Fairy save(Fairy fairy);
+
+    Optional<Fairy> findById(Long id);
+
+    List<Fairy> findAllByEmotionIdIn(List<Long> emotionIds);
+}

--- a/src/main/java/com/nexters/teamace/fairy/infrastructure/FairyEntity.java
+++ b/src/main/java/com/nexters/teamace/fairy/infrastructure/FairyEntity.java
@@ -1,0 +1,54 @@
+package com.nexters.teamace.fairy.infrastructure;
+
+import com.nexters.teamace.emotion.infrastructure.EmotionEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "fairy")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FairyEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "fairy_id")
+    private Long id;
+
+    private String name;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    @Column(name = "silhouette_image_url")
+    private String silhouetteImageUrl;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "emotion_id")
+    private EmotionEntity emotion;
+
+    @Builder
+    public FairyEntity(
+            Long id,
+            String name,
+            String imageUrl,
+            String silhouetteImageUrl,
+            EmotionEntity emotion) {
+        this.id = id;
+        this.name = name;
+        this.imageUrl = imageUrl;
+        this.silhouetteImageUrl = silhouetteImageUrl;
+        this.emotion = emotion;
+    }
+}

--- a/src/main/java/com/nexters/teamace/fairy/infrastructure/FairyJpaRepository.java
+++ b/src/main/java/com/nexters/teamace/fairy/infrastructure/FairyJpaRepository.java
@@ -1,0 +1,9 @@
+package com.nexters.teamace.fairy.infrastructure;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FairyJpaRepository extends JpaRepository<FairyEntity, Long> {
+
+    List<FairyEntity> findAllByEmotionIdIn(List<Long> emotionIds);
+}

--- a/src/main/java/com/nexters/teamace/fairy/infrastructure/FairyMapper.java
+++ b/src/main/java/com/nexters/teamace/fairy/infrastructure/FairyMapper.java
@@ -1,0 +1,51 @@
+package com.nexters.teamace.fairy.infrastructure;
+
+import com.nexters.teamace.emotion.domain.Emotion;
+import com.nexters.teamace.emotion.infrastructure.EmotionEntity;
+import com.nexters.teamace.fairy.domain.Fairy;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FairyMapper {
+
+    public Fairy toDomain(FairyEntity entity) {
+        if (entity == null) {
+            return null;
+        }
+        Emotion emotion = null;
+        if (entity.getEmotion() != null) {
+            emotion =
+                    new Emotion(
+                            entity.getEmotion().getId(),
+                            entity.getEmotion().getName(),
+                            entity.getEmotion().getDescription());
+        }
+        return new Fairy(
+                entity.getId(),
+                entity.getName(),
+                entity.getImageUrl(),
+                entity.getSilhouetteImageUrl(),
+                emotion);
+    }
+
+    public FairyEntity toEntity(Fairy fairy) {
+        if (fairy == null) {
+            return null;
+        }
+
+        EmotionEntity emotionEntity = null;
+        if (fairy.getEmotion() != null) {
+            emotionEntity =
+                    new EmotionEntity(
+                            fairy.getEmotion().getName(), fairy.getEmotion().getDescription());
+        }
+
+        return FairyEntity.builder()
+                .id(fairy.getId())
+                .name(fairy.getName())
+                .imageUrl(fairy.getImageUrl())
+                .silhouetteImageUrl(fairy.getSilhouetteImageUrl())
+                .emotion(emotionEntity)
+                .build();
+    }
+}

--- a/src/main/java/com/nexters/teamace/fairy/infrastructure/FairyRepositoryImpl.java
+++ b/src/main/java/com/nexters/teamace/fairy/infrastructure/FairyRepositoryImpl.java
@@ -1,0 +1,35 @@
+package com.nexters.teamace.fairy.infrastructure;
+
+import com.nexters.teamace.fairy.domain.Fairy;
+import com.nexters.teamace.fairy.domain.FairyRepository;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class FairyRepositoryImpl implements FairyRepository {
+
+    private final FairyJpaRepository fairyJpaRepository;
+    private final FairyMapper fairyMapper;
+
+    @Override
+    public Fairy save(Fairy fairy) {
+        FairyEntity entity = fairyMapper.toEntity(fairy);
+        FairyEntity savedEntity = fairyJpaRepository.save(entity);
+        return fairyMapper.toDomain(savedEntity);
+    }
+
+    @Override
+    public Optional<Fairy> findById(Long id) {
+        return fairyJpaRepository.findById(id).map(fairyMapper::toDomain);
+    }
+
+    @Override
+    public List<Fairy> findAllByEmotionIdIn(List<Long> emotionIds) {
+        return fairyJpaRepository.findAllByEmotionIdIn(emotionIds).stream()
+                .map(fairyMapper::toDomain)
+                .toList();
+    }
+}

--- a/src/main/java/com/nexters/teamace/fairy/presentation/FairyController.java
+++ b/src/main/java/com/nexters/teamace/fairy/presentation/FairyController.java
@@ -1,0 +1,26 @@
+package com.nexters.teamace.fairy.presentation;
+
+import com.nexters.teamace.common.presentation.ApiResponse;
+import com.nexters.teamace.common.presentation.AuthUser;
+import com.nexters.teamace.fairy.application.FairyResult;
+import com.nexters.teamace.fairy.application.FairyService;
+import com.nexters.teamace.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/fairies")
+public class FairyController {
+
+    private final FairyService fairyService;
+
+    @GetMapping
+    public ApiResponse<FairyResponse> getFairy(@AuthUser User user, @RequestParam Long chatRoomId) {
+        FairyResult result = fairyService.getFairy(user, chatRoomId);
+        return ApiResponse.success(new FairyResponse(result.fairies()));
+    }
+}

--- a/src/main/java/com/nexters/teamace/fairy/presentation/FairyResponse.java
+++ b/src/main/java/com/nexters/teamace/fairy/presentation/FairyResponse.java
@@ -1,0 +1,6 @@
+package com.nexters.teamace.fairy.presentation;
+
+import com.nexters.teamace.fairy.application.FairyCandidate;
+import java.util.List;
+
+public record FairyResponse(List<FairyCandidate> fairies) {}

--- a/src/main/resources/db/migration/V2__Create_emotion_and_fairy_schema.sql
+++ b/src/main/resources/db/migration/V2__Create_emotion_and_fairy_schema.sql
@@ -1,0 +1,26 @@
+CREATE TABLE emotions
+(
+    id          BIGINT PRIMARY KEY                  NOT NULL AUTO_INCREMENT,
+    name        VARCHAR(255)                        NOT NULL UNIQUE,
+    description VARCHAR(255),
+    created_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    created_id  VARCHAR(255)                        NOT NULL,
+    updated_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL,
+    updated_id  VARCHAR(255)                        NOT NULL,
+    deleted_at  TIMESTAMP NULL
+);
+
+CREATE TABLE fairies
+(
+    id                   BIGINT PRIMARY KEY,
+    name                 VARCHAR(255)                        NOT NULL UNIQUE,
+    image_url            VARCHAR(255),
+    silhouette_image_url VARCHAR(255),
+    emotion_id           BIGINT,
+    created_at           TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    created_id           VARCHAR(255)                        NOT NULL,
+    updated_at           TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NOT NULL,
+    updated_id           VARCHAR(255)                        NOT NULL,
+    deleted_at           TIMESTAMP NULL,
+    FOREIGN KEY (emotion_id) REFERENCES emotions (id)
+);

--- a/src/test/java/com/nexters/teamace/common/utils/ControllerTest.java
+++ b/src/test/java/com/nexters/teamace/common/utils/ControllerTest.java
@@ -8,10 +8,12 @@ import com.nexters.teamace.auth.application.TokenService;
 import com.nexters.teamace.auth.config.SecurityConfig;
 import com.nexters.teamace.auth.infrastructure.security.JwtAuthenticationFilter;
 import com.nexters.teamace.auth.infrastructure.security.SecurityErrorHandler;
+import com.nexters.teamace.auth.presentation.AuthUserArgumentResolver;
 import com.nexters.teamace.chat.application.ChatRoomService;
 import com.nexters.teamace.common.presentation.GlobalExceptionHandler;
 import com.nexters.teamace.conversation.application.ConversationClient;
 import com.nexters.teamace.conversation.application.ConversationService;
+import com.nexters.teamace.fairy.application.FairyService;
 import com.nexters.teamace.user.application.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
@@ -39,6 +41,8 @@ public abstract class ControllerTest {
     @MockitoBean protected UserService userService;
     @MockitoBean protected ConversationService conversationService;
     @MockitoBean protected ConversationClient conversationClient;
+    @MockitoBean protected FairyService fairyService;
+    @MockitoBean protected AuthUserArgumentResolver authUserArgumentResolver;
 
     protected Object asParsedJson(Object obj) throws JsonProcessingException {
         String json = objectMapper.writeValueAsString(obj);

--- a/src/test/java/com/nexters/teamace/fairy/presentation/FairyControllerTest.java
+++ b/src/test/java/com/nexters/teamace/fairy/presentation/FairyControllerTest.java
@@ -1,0 +1,119 @@
+package com.nexters.teamace.fairy.presentation;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static com.epages.restdocs.apispec.Schema.schema;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.nexters.teamace.common.utils.ControllerTest;
+import com.nexters.teamace.fairy.application.FairyCandidate;
+import com.nexters.teamace.fairy.application.FairyResult;
+import com.nexters.teamace.user.domain.User;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.ResultActions;
+
+class FairyControllerTest extends ControllerTest {
+
+    @Test
+    @DisplayName("인증된 사용자는 요정 추천을 받을 수 있다")
+    @WithMockUser
+    void getFairy_success() throws Exception {
+        // given
+        long chatRoomId = 100L;
+        User user = new User("test-user", "테스트유저");
+
+        given(authUserArgumentResolver.resolveArgument(any(), any(), any(), any()))
+                .willReturn(user);
+
+        List<FairyCandidate> candidates =
+                List.of(new FairyCandidate(1L, "눈물방울 요정", "sad.png", "sad_sil.png", "슬픔"));
+        List.of(new FairyCandidate(1L, "분노끄아앙 요정", "angry.png", "angry_sil.png", "분노"));
+        FairyResult fairyResult = new FairyResult(candidates);
+
+        given(fairyService.getFairy(any(User.class), any(Long.class))).willReturn(fairyResult);
+
+        // when
+        ResultActions resultActions =
+                mockMvc.perform(
+                        get("/api/v1/fairies").param("chatRoomId", String.valueOf(chatRoomId)));
+
+        // then
+        FairyResponse expectedResponse = new FairyResponse(candidates);
+
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data", equalTo(asParsedJson(expectedResponse))))
+                .andExpect(jsonPath("$.error").doesNotExist())
+                .andDo(
+                        MockMvcRestDocumentationWrapper.document(
+                                "{class_name}/{method_name}",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                resource(
+                                        ResourceSnippetParameters.builder()
+                                                .tag("Fairy")
+                                                .description("채팅방 기반 요정 추천 조회")
+                                                .responseFields(
+                                                        fieldWithPath("success")
+                                                                .type(JsonFieldType.BOOLEAN)
+                                                                .description("성공 여부"),
+                                                        fieldWithPath("data.fairies")
+                                                                .type(JsonFieldType.ARRAY)
+                                                                .description("추천된 요정 목록"),
+                                                        fieldWithPath("data.fairies[].id")
+                                                                .type(JsonFieldType.NUMBER)
+                                                                .description("요정 ID"),
+                                                        fieldWithPath("data.fairies[].name")
+                                                                .type(JsonFieldType.STRING)
+                                                                .description("요정 이름"),
+                                                        fieldWithPath("data.fairies[].image")
+                                                                .type(JsonFieldType.STRING)
+                                                                .description("요정 이미지 URL"),
+                                                        fieldWithPath(
+                                                                        "data.fairies[].silhouetteImage")
+                                                                .type(JsonFieldType.STRING)
+                                                                .description("요정 실루엣 이미지 URL"),
+                                                        fieldWithPath("data.fairies[].emotion")
+                                                                .type(JsonFieldType.STRING)
+                                                                .description("관련 감정"),
+                                                        fieldWithPath("error")
+                                                                .type(JsonFieldType.NULL)
+                                                                .description("에러 정보 (성공 시 null)"))
+                                                .responseSchema(schema("FairyResponse"))
+                                                .build())));
+    }
+
+    @Test
+    @DisplayName("인증되지 않은 사용자는 401 Unauthorized 에러를 받는다")
+    void getFairy_unauthorized() throws Exception {
+        // given
+        long chatRoomId = 100L;
+
+        // when
+        ResultActions resultActions =
+                mockMvc.perform(
+                        get("/api/v1/fairies")
+                                .param(
+                                        "chatRoomId",
+                                        String.valueOf(
+                                                chatRoomId))); // @WithMockUser가 없으므로 인증되지 않은 상태로 요청
+
+        // then
+        resultActions.andExpect(status().isUnauthorized());
+    }
+}


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feat(#133): canvas 구현~ -->
<!-- 💡 브랜치 이름이 feature/5, fix/123 등인 경우 숫자가 이슈 번호입니다 -->
<!-- "여기에 작성하세요", "(필수 X)"는 지우고 작성하세요 🙏🏻 -->

## 📌 관련 이슈
<!-- 이슈 번호를 #숫자 형식으로 작성하면 자동으로 연결됩니다 -->
<!-- ex) #5, closes #5, fixes #5 -->
closes #35 

## 📝 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
채팅 내용 기반 감정 요정 후보 추천 받는 API 구현

## ✅ 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
- presentation layer에서 security에 의존하지 않고 user 정보 주입받기 위한 argument resolver 추가
- emotion, fairy 테이블, 도메인 추가

## 💭 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->
- argument resolver를 controller test의 포함 영역으로 볼지?
    - 일단 모킹해두었는데 포함시킬 거면 userService를 mocking하고 resolver는 실제로 동작하도록 변경해야 할듯
