### PR TITLE
Feature(#41): 감정 선택 시 프롬프트 생성을 위한 전체 채팅 조회 기능

### DIFF
--- a/src/main/java/com/nexters/teamace/chat/application/AllChatQuery.java
+++ b/src/main/java/com/nexters/teamace/chat/application/AllChatQuery.java
@@ -1,0 +1,14 @@
+package com.nexters.teamace.chat.application;
+
+import com.nexters.teamace.common.exception.ValidationErrorMessage;
+
+public record AllChatQuery(Long chatRoomId) {
+    public AllChatQuery {
+        if (chatRoomId == null) {
+            throw new IllegalArgumentException(ValidationErrorMessage.CHAT_ROOM_ID_NOT_NULL);
+        }
+        if (chatRoomId < 1) {
+            throw new IllegalArgumentException(ValidationErrorMessage.CHAT_ROOM_ID_POSITIVE);
+        }
+    }
+}

--- a/src/main/java/com/nexters/teamace/chat/application/AllChatResult.java
+++ b/src/main/java/com/nexters/teamace/chat/application/AllChatResult.java
@@ -1,0 +1,9 @@
+package com.nexters.teamace.chat.application;
+
+import com.nexters.teamace.chat.domain.MessageType;
+import java.util.List;
+
+public record AllChatResult(Long chatRoomId, List<ChatResult> chats) {
+
+    public record ChatResult(Long chatId, MessageType type, String message) {}
+}

--- a/src/main/java/com/nexters/teamace/chat/application/ChatRoomService.java
+++ b/src/main/java/com/nexters/teamace/chat/application/ChatRoomService.java
@@ -4,6 +4,7 @@ import com.nexters.teamace.chat.domain.ChatContext;
 import com.nexters.teamace.chat.domain.ChatMessageGenerator;
 import com.nexters.teamace.chat.domain.ChatRoom;
 import com.nexters.teamace.chat.domain.ChatRoomRepository;
+import com.nexters.teamace.common.infrastructure.annotation.ReadOnlyTransactional;
 import com.nexters.teamace.user.application.GetUserResult;
 import com.nexters.teamace.user.application.UserService;
 import lombok.RequiredArgsConstructor;
@@ -43,5 +44,18 @@ public class ChatRoomService {
         chatRoomRepository.save(chatRoom);
 
         return new SendMessageResult(responseMessage);
+    }
+
+    @ReadOnlyTransactional
+    public AllChatResult getAllChats(final AllChatQuery query) {
+        final ChatRoom chatRoom = chatRoomRepository.getById(query.chatRoomId());
+        return new AllChatResult(
+                chatRoom.getId(),
+                chatRoom.getChats().stream()
+                        .map(
+                                chat ->
+                                        new AllChatResult.ChatResult(
+                                                chat.getId(), chat.getType(), chat.getMessage()))
+                        .toList());
     }
 }

--- a/src/main/java/com/nexters/teamace/common/infrastructure/annotation/ReadOnlyTransactional.java
+++ b/src/main/java/com/nexters/teamace/common/infrastructure/annotation/ReadOnlyTransactional.java
@@ -1,0 +1,13 @@
+package com.nexters.teamace.common.infrastructure.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
+public @interface ReadOnlyTransactional {}


### PR DESCRIPTION
## 📌 관련 이슈

closes #41 

## 📝 작업 개요

- 감정 선택 시 프롬프트 생성을 위한 전체 채팅 조회 기능

## ✅ 작업 사항

- [x] `ChatRoomService` 기능 추가

## 💭 고민한 점들(필수 X)

- `@ReadOnlyTransaction` 추가
- [카카오페이 기술블로그 - JPA Transactional 잘 알고 쓰고 계신가요?](https://tech.kakaopay.com/post/jpa-transactional-bri/) 이 글 한 번 읽어보면 좋을듯!

```java
@Target({ElementType.TYPE, ElementType.METHOD})
@Retention(RetentionPolicy.RUNTIME)
@Transactional(readOnly = true, propagation = Propagation.SUPPORTS)
public @interface ReadOnlyTransactional {}
```
