### PR TITLE
Feature(#60): UT 대비 토큰 수명 수정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,7 +43,7 @@ decorator:
 
 jwt:
   secret: ${JWT_SECRET:dGVhbS1hY2UtYmFja2VuZC1kZWZhdWx0LXNlY3JldC1rZXktZm9yLWRldmVsb3BtZW50LW9ubHk=}
-  access-token-validity: ${JWT_ACCESS_TOKEN_VALIDITY:3600000}
+  access-token-validity: ${JWT_ACCESS_TOKEN_VALIDITY:604800000}
   refresh-token-validity: ${JWT_REFRESH_TOKEN_VALIDITY:604800000}
 
 gemini:


### PR DESCRIPTION
## 📌 관련 이슈

closes #60 

## 📝 작업 개요

- UT 대비 토큰 수명 수정

## ✅ 작업 사항

- [x] AccessToken 만료시간 1시간 -> 7일



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * JWT 액세스 토큰의 기본 유효 기간이 1시간에서 7일로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->