### PR TITLE
[#59] slack webhook 변수 추가의 sed 오류 해결

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,7 +29,7 @@ jobs:
           sed -i 's/${DB_USERNAME:[^}]*}/${{ secrets.DB_USERNAME }}/g' src/main/resources/application.yml
           sed -i 's/${DB_PASSWORD:[^}]*}/${{ secrets.DB_PASSWORD }}/g' src/main/resources/application.yml
           sed -i 's/${GEMINI_API_KEY:[^}]*}/${{ secrets.GEMINI_API_KEY }}/g' src/main/resources/application.yml
-          sed -i 's/${SLACK_WEBHOOK_URL:[^}]*}/${{ secrets.SLACK_WEBHOOK_URL }}/g' src/main/resources/application.yml
+          sed -i 's|${SLACK_WEBHOOK_URL:[^}]*}|${{ secrets.SLACK_WEBHOOK_URL }}|g' src/main/resources/application.yml
 
       - name: Setup Gradle cache
         uses: actions/cache@v4


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feat(#133): canvas 구현~ -->
<!-- 💡 브랜치 이름이 feature/5, fix/123 등인 경우 숫자가 이슈 번호입니다 -->
<!-- "여기에 작성하세요", "(필수 X)"는 지우고 작성하세요 🙏🏻 -->

## 📌 관련 이슈
<!-- 이슈 번호를 #숫자 형식으로 작성하면 자동으로 연결됩니다 -->
<!-- ex) #5, closes #5, fixes #5 -->
#59

## 📝 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
이럴 수가.. slack webhook url에 포함된 '/' 문자열과 sed의 구분자가 충돌해서 cd script가 터졌습니다.

## ✅ 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
slack webhook 시크릿 변수의 sed 구분자만 /에서 |로 조치

## 💭 고민한 점들
일단 임시조치고, sed 사용하는 것 자체를 바꿔야 할듯


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 배포 워크플로우에서 환경 변수 치환 명령어의 구분자를 변경하여 처리 방식을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->