### PR TITLE
Feature/16 DB 컨테이너를 compose에 포함

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: main # 배포는 항상 main 브랜치 기준으로 실행
 
       - name: Set up Java
         uses: actions/setup-java@v4
@@ -65,6 +63,18 @@ jobs:
           platforms: linux/amd64
           tags: ${{ secrets.REGISTRY_URL }}/${{ secrets.IMAGE_NAME }}:${{ github.sha }}
 
+      - name: Upload docker-compose.yml to Server
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USERNAME }}
+          password: ${{ secrets.SERVER_PASSWORD }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          source: "docker-compose-deploy.yml"
+          target: "~/app/"
+          overwrite: true
+          debug: true
+
       - name: Deploy to Server
         uses: appleboy/ssh-action@master
         with:
@@ -73,21 +83,26 @@ jobs:
           password: ${{ secrets.SERVER_PASSWORD }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
-            CONTAINER_NAME=gamchi-app
-            NETWORK_NAME=gamchi-network
-            
-            docker login -u ${{ secrets.REGISTRY_USERNAME }} -p ${{ secrets.REGISTRY_PASSWORD }} ${{ secrets.REGISTRY_URL }}
-            docker pull ${{ secrets.REGISTRY_URL }}/${{ secrets.IMAGE_NAME }}:${{ github.sha }}
-            
-            if [ $(docker ps -a -q --filter "name=$CONTAINER_NAME") ]; then
-              docker stop $CONTAINER_NAME
-              docker rm $CONTAINER_NAME
+            DEPLOY_DIR=~/app
+            mkdir -p $DEPLOY_DIR
+            cd $DEPLOY_DIR
+
+            if [ ! -f docker-compose-deploy.yml ]; then
+              echo "ERROR: docker-compose-deploy.yml does not exist in $DEPLOY_DIR"
+              exit 1
+            else
+              echo "Found docker-compose-deploy.yml, renaming to docker-compose.yml"
+              mv docker-compose-deploy.yml docker-compose.yml
             fi
-            
-            docker run -d \
-              --name $CONTAINER_NAME \
-              --network $NETWORK_NAME \
-              -p 8080:8080 \
-              ${{ secrets.REGISTRY_URL }}/${{ secrets.IMAGE_NAME }}:${{ github.sha }}
-            
+
+            echo "IMAGE_TAG=${{ secrets.REGISTRY_URL }}/${{ secrets.IMAGE_NAME }}:${{ github.sha }}" > .env
+            echo "DB_USERNAME=${{ secrets.DB_USERNAME }}" >> .env
+            echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> .env
+
+            docker login -u ${{ secrets.REGISTRY_USERNAME }} -p ${{ secrets.REGISTRY_PASSWORD }} ${{ secrets.REGISTRY_URL }}
+
+            docker compose pull app
+
+            docker compose up -d
+
             docker image prune -a -f

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,15 +20,6 @@ jobs:
           java-version: '24'
           distribution: 'oracle'
 
-      - name: Replace placeholders with secrets
-        run: |
-          sed -i 's/${JWT_SECRET:[^}]*}/${{ secrets.JWT_SECRET }}/g' src/main/resources/application.yml
-          sed -i 's/${DB_HOST:[^}]*}/${{ secrets.DB_HOST }}/g' src/main/resources/application.yml
-          sed -i 's/${DB_USERNAME:[^}]*}/${{ secrets.DB_USERNAME }}/g' src/main/resources/application.yml
-          sed -i 's/${DB_PASSWORD:[^}]*}/${{ secrets.DB_PASSWORD }}/g' src/main/resources/application.yml
-          sed -i 's/${GEMINI_API_KEY:[^}]*}/${{ secrets.GEMINI_API_KEY }}/g' src/main/resources/application.yml
-          sed -i 's|${SLACK_WEBHOOK_URL:[^}]*}|${{ secrets.SLACK_WEBHOOK_URL }}|g' src/main/resources/application.yml
-
       - name: Setup Gradle cache
         uses: actions/cache@v4
         with:
@@ -96,8 +87,13 @@ jobs:
             fi
 
             echo "IMAGE_TAG=${{ secrets.REGISTRY_URL }}/${{ secrets.IMAGE_NAME }}:${{ github.sha }}" > .env
+            echo "DB_HOST=${{ secrets.DB_HOST }}" >> .env
             echo "DB_USERNAME=${{ secrets.DB_USERNAME }}" >> .env
             echo "DB_PASSWORD=${{ secrets.DB_PASSWORD }}" >> .env
+            echo "DB_ROOT_PASSWORD=${{ secrets.DB_ROOT_PASSWORD }}" >> .env
+            echo "JWT_SECRET=${{ secrets.JWT_SECRET }}" >> .env
+            echo "GEMINI_API_KEY=${{ secrets.GEMINI_API_KEY }}" >> .env
+            echo "SLACK_WEBHOOK_URL=${{ secrets.SLACK_WEBHOOK_URL }}" >> .env
 
             docker login -u ${{ secrets.REGISTRY_USERNAME }} -p ${{ secrets.REGISTRY_PASSWORD }} ${{ secrets.REGISTRY_URL }}
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Java
         uses: actions/setup-java@v4
@@ -64,7 +64,7 @@ jobs:
           tags: ${{ secrets.REGISTRY_URL }}/${{ secrets.IMAGE_NAME }}:${{ github.sha }}
 
       - name: Upload docker-compose.yml to Server
-        uses: appleboy/scp-action@master
+        uses: appleboy/scp-action@v1
         with:
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USERNAME }}
@@ -76,7 +76,7 @@ jobs:
           debug: true
 
       - name: Deploy to Server
-        uses: appleboy/ssh-action@master
+        uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USERNAME }}
@@ -103,6 +103,7 @@ jobs:
 
             docker compose pull app
 
-            docker compose up -d
+            docker compose up -d --no-recreate db
+            docker compose up -d app
 
             docker image prune -a -f

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Java
         uses: actions/setup-java@v4

--- a/.github/workflows/deploy-swagger.yml
+++ b/.github/workflows/deploy-swagger.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up JDK 24
         uses: actions/setup-java@v4
@@ -29,7 +29,7 @@ jobs:
         run: ./gradlew openapi3
 
       - name: Copy OpenAPI files to server
-        uses: appleboy/scp-action@master
+        uses: appleboy/scp-action@v1
         with:
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USERNAME }}

--- a/docker-compose-deploy.yml
+++ b/docker-compose-deploy.yml
@@ -10,6 +10,7 @@ services:
       MYSQL_DATABASE: gamchi
       MYSQL_USER: ${DB_USERNAME}
       MYSQL_PASSWORD: ${DB_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
     command:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci
@@ -34,6 +35,8 @@ services:
     networks:
       - gamchi-network
     restart: always
+    env_file:
+      - .env
 
 volumes:
   mysql_data:

--- a/docker-compose-deploy.yml
+++ b/docker-compose-deploy.yml
@@ -1,0 +1,44 @@
+services:
+  db:
+    image: mysql:8
+    container_name: gamchi-db
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+    environment:
+      MYSQL_DATABASE: gamchi
+      MYSQL_USER: ${DB_USERNAME}
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+    networks:
+      - gamchi-network
+    restart: always
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "${DB_USERNAME}", "-p${DB_PASSWORD}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  app:
+    image: ${IMAGE_TAG}
+    container_name: gamchi-app
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - "8080:8080"
+    networks:
+      - gamchi-network
+    restart: always
+
+volumes:
+  mysql_data:
+    external: true
+
+networks:
+  gamchi-network:
+    driver: bridge


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feat(#133): canvas 구현~ -->
<!-- 💡 브랜치 이름이 feature/5, fix/123 등인 경우 숫자가 이슈 번호입니다 -->
<!-- "여기에 작성하세요", "(필수 X)"는 지우고 작성하세요 🙏🏻 -->

## 📌 관련 이슈
<!-- 이슈 번호를 #숫자 형식으로 작성하면 자동으로 연결됩니다 -->
<!-- ex) #5, closes #5, fixes #5 -->
#16

## 📝 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
#51 에서 논의한 것과 같이, 배포용 compose를 만든 다음 mysql 컨테이너를 app 컨테이너랑 동일 compose로 그룹화 했습니당

## ✅ 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
- [x] CD에서 compose 파일 올리고 원격 서버에서 compose로 구동
- [x] 일부 action 버전업 및 버전 고정(의도치 않은 side-effect 예방을 위함)

## 💭 고민한 점들(필수 X)
- db health check가 안 되면 app도 안 뜨게 구성해서 db가 죽었는데 app만 불필요하게 구동되는 상황을 막았음
- app만 up하지 않고 compose up 하나로 퉁치는 이유는, 어차피 db는 변동사항 없으면 recreate되지 않을 것이기 때문
- 모든 컨테이너 설정을 소스레벨에서 관리할 수 있다는 점, 동일 네트워크로 쉽게 묶을 수 있다는 점 등은 매우 장점
- 하지만 추후 DB같은 외부 시스템을 별도 서버로 분리할 때 변경해줘야 한다는 것 (배포 스크립트 자체가 현재 서버 아키에 대한 의존성이 생긴다는 점) 은 약간 단점일 수도?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - 서버 배포를 개별 컨테이너 실행에서 Compose 기반 오케스트레이션으로 전환해 롤아웃 일관성과 서비스 의존성 관리를 강화했습니다.
  - 배포 스크립트를 재구성하고 불필요한 정지/제거 절차를 제거해 배포 흐름을 간소화하고 이미지 정리 등을 자동화했습니다.
- New Features
  - 배포용 Compose 구성과 DB·앱 서비스 정의를 추가해 환경변수 기반 설정 로드 및 헬스체크 기반 순차 기동을 지원합니다.
- Chores
  - CI/CD 액션 버전 업그레이드 및 배포 파일 업로드·SSH 실행 단계 도입으로 파이프라인 안정성과 동기화를 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->