### PR TITLE
[#58] feat: 요정 후보 추천에 감정 상세설명 데이터 추가

### DIFF
--- a/src/main/java/com/nexters/teamace/fairy/application/FairyService.java
+++ b/src/main/java/com/nexters/teamace/fairy/application/FairyService.java
@@ -101,7 +101,8 @@ public class FairyService {
                                         p.name(),
                                         p.image(),
                                         p.silhouetteImage(),
-                                        p.emotionName().getDisplayName()))
+                                        p.emotionName().getDisplayName(),
+                                        p.emotionDescription()))
                 .toList();
     }
 

--- a/src/main/java/com/nexters/teamace/fairy/application/dto/FairyInfo.java
+++ b/src/main/java/com/nexters/teamace/fairy/application/dto/FairyInfo.java
@@ -1,4 +1,9 @@
 package com.nexters.teamace.fairy.application.dto;
 
 public record FairyInfo(
-        Long id, String name, String image, String silhouetteImage, String emotion) {}
+        Long id,
+        String name,
+        String image,
+        String silhouetteImage,
+        String emotion,
+        String emotionDescription) {}

--- a/src/main/java/com/nexters/teamace/fairy/infrastructure/FairyJpaRepository.java
+++ b/src/main/java/com/nexters/teamace/fairy/infrastructure/FairyJpaRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.repository.query.Param;
 public interface FairyJpaRepository extends JpaRepository<FairyEntity, Long> {
 
     @Query(
-            "SELECT new com.nexters.teamace.fairy.infrastructure.dto.FairyProjection(f.id, f.name, f.imageUrl, f.silhouetteImageUrl, e.name) "
+            "SELECT new com.nexters.teamace.fairy.infrastructure.dto.FairyProjection(f.id, f.name, f.imageUrl, f.silhouetteImageUrl, e.name, e.description) "
                     + "FROM FairyEntity f JOIN f.emotion e "
                     + "WHERE e.name IN :emotionNames")
     List<FairyProjection> findAllByEmotionNames(

--- a/src/main/java/com/nexters/teamace/fairy/infrastructure/dto/FairyProjection.java
+++ b/src/main/java/com/nexters/teamace/fairy/infrastructure/dto/FairyProjection.java
@@ -3,4 +3,9 @@ package com.nexters.teamace.fairy.infrastructure.dto;
 import com.nexters.teamace.emotion.domain.EmotionName;
 
 public record FairyProjection(
-        Long id, String name, String image, String silhouetteImage, EmotionName emotionName) {}
+        Long id,
+        String name,
+        String image,
+        String silhouetteImage,
+        EmotionName emotionName,
+        String emotionDescription) {}

--- a/src/test/java/com/nexters/teamace/fairy/presentation/FairyControllerTest.java
+++ b/src/test/java/com/nexters/teamace/fairy/presentation/FairyControllerTest.java
@@ -42,9 +42,17 @@ class FairyControllerTest extends ControllerTest {
 
         List<FairyInfo> fairyInfos =
                 List.of(
-                        new FairyInfo(1L, "눈물방울 요정", "sadness.png", "sadness_sil.png", "슬픔"),
-                        new FairyInfo(2L, "화르르 요정", "anger.png", "anger_sil.png", "분노"),
-                        new FairyInfo(3L, "질투쟁이 요정", "jealousy.png", "jealousy_sil.png", "질투"));
+                        new FairyInfo(
+                                1L, "눈물방울 요정", "sadness.png", "sadness_sil.png", "슬픔", "너무 슬프다는 뜻"),
+                        new FairyInfo(
+                                2L, "화르르 요정", "anger.png", "anger_sil.png", "분노", "너무 화가 난다는 뜻"),
+                        new FairyInfo(
+                                3L,
+                                "질투쟁이 요정",
+                                "jealousy.png",
+                                "jealousy_sil.png",
+                                "질투",
+                                "매우 질투가 난다는 뜻"));
         FairyResult fairyResult = new FairyResult(fairyInfos);
 
         given(fairyService.getFairy(any(UserInfo.class), any(Long.class))).willReturn(fairyResult);
@@ -97,6 +105,10 @@ class FairyControllerTest extends ControllerTest {
                                                         fieldWithPath("data.fairies[].emotion")
                                                                 .type(JsonFieldType.STRING)
                                                                 .description("관련 감정"),
+                                                        fieldWithPath(
+                                                                        "data.fairies[].emotionDescription")
+                                                                .type(JsonFieldType.STRING)
+                                                                .description("관련 감정에 대한 상세 설명"),
                                                         fieldWithPath("error")
                                                                 .type(JsonFieldType.NULL)
                                                                 .description("에러 정보 (성공 시 null)"))


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feat(#133): canvas 구현~ -->
<!-- 💡 브랜치 이름이 feature/5, fix/123 등인 경우 숫자가 이슈 번호입니다 -->
<!-- "여기에 작성하세요", "(필수 X)"는 지우고 작성하세요 🙏🏻 -->

## 📌 관련 이슈
<!-- 이슈 번호를 #숫자 형식으로 작성하면 자동으로 연결됩니다 -->
<!-- ex) #5, closes #5, fixes #5 -->
#58

## 📝 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
요정 후보 추천에 감정 상세설명 데이터가 빠져서 추가했음

## ✅ 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
- [x] 요정 후보 추천에 감정 상세설명 데이터 추가



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 요정 정보에 감정 설명(emotionDescription) 필드를 추가했습니다. 요정 목록/상세 조회 시 감정명과 함께 설명이 함께 표시되어 더 풍부한 정보를 제공합니다.
- 문서
  - API 응답 스키마와 예시에 emotionDescription 항목을 반영했습니다.
- 테스트
  - 새로운 emotionDescription 필드를 검증하도록 테스트와 API 문서화 테스트를 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->