### PR TITLE
[#10] feat: User 관련 길이 제한을 도메인으로 이동

### DIFF
--- a/src/main/java/com/nexters/teamace/auth/application/LoginCommand.java
+++ b/src/main/java/com/nexters/teamace/auth/application/LoginCommand.java
@@ -2,6 +2,7 @@ package com.nexters.teamace.auth.application;
 
 import static com.nexters.teamace.common.exception.ValidationErrorMessage.*;
 
+import com.nexters.teamace.user.domain.User;
 import org.springframework.util.StringUtils;
 
 public record LoginCommand(String username) {
@@ -9,7 +10,7 @@ public record LoginCommand(String username) {
         if (!StringUtils.hasText(username)) {
             throw new IllegalArgumentException(USERNAME_NOT_BLANK);
         }
-        if (username.length() > 20) {
+        if (username.length() > User.MAX_USERNAME_LENGTH) {
             throw new IllegalArgumentException(USERNAME_SIZE);
         }
     }

--- a/src/main/java/com/nexters/teamace/auth/application/SignupCommand.java
+++ b/src/main/java/com/nexters/teamace/auth/application/SignupCommand.java
@@ -2,6 +2,7 @@ package com.nexters.teamace.auth.application;
 
 import static com.nexters.teamace.common.exception.ValidationErrorMessage.*;
 
+import com.nexters.teamace.user.domain.User;
 import org.springframework.util.StringUtils;
 
 public record SignupCommand(String username, String nickname) {
@@ -9,13 +10,13 @@ public record SignupCommand(String username, String nickname) {
         if (!StringUtils.hasText(username)) {
             throw new IllegalArgumentException(USERNAME_NOT_BLANK);
         }
-        if (username.length() > 20) {
+        if (username.length() > User.MAX_USERNAME_LENGTH) {
             throw new IllegalArgumentException(USERNAME_SIZE);
         }
         if (!StringUtils.hasText(nickname)) {
             throw new IllegalArgumentException(NICKNAME_NOT_BLANK);
         }
-        if (nickname.length() > 20) {
+        if (nickname.length() > User.MAX_NICKNAME_LENGTH) {
             throw new IllegalArgumentException(NICKNAME_SIZE);
         }
     }

--- a/src/main/java/com/nexters/teamace/auth/presentation/SignupRequest.java
+++ b/src/main/java/com/nexters/teamace/auth/presentation/SignupRequest.java
@@ -1,13 +1,20 @@
 package com.nexters.teamace.auth.presentation;
 
 import com.nexters.teamace.common.exception.ValidationErrorMessage;
+import com.nexters.teamace.user.domain.User;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record SignupRequest(
         @NotBlank(message = ValidationErrorMessage.USERNAME_NOT_BLANK)
-                @Size(min = 1, max = 20, message = ValidationErrorMessage.USERNAME_SIZE)
+                @Size(
+                        min = 1,
+                        max = User.MAX_USERNAME_LENGTH,
+                        message = ValidationErrorMessage.USERNAME_SIZE)
                 String username,
         @NotBlank(message = ValidationErrorMessage.NICKNAME_NOT_BLANK)
-                @Size(min = 1, max = 20, message = ValidationErrorMessage.NICKNAME_SIZE)
+                @Size(
+                        min = 1,
+                        max = User.MAX_NICKNAME_LENGTH,
+                        message = ValidationErrorMessage.NICKNAME_SIZE)
                 String nickname) {}

--- a/src/main/java/com/nexters/teamace/common/exception/ValidationErrorMessage.java
+++ b/src/main/java/com/nexters/teamace/common/exception/ValidationErrorMessage.java
@@ -1,5 +1,7 @@
 package com.nexters.teamace.common.exception;
 
+import com.nexters.teamace.user.domain.User;
+
 public class ValidationErrorMessage {
 
     /** Auth */
@@ -9,9 +11,11 @@ public class ValidationErrorMessage {
     public static final String USER_ID_NOT_NULL = "User ID cannot be null";
 
     public static final String USER_ID_POSITIVE = "User ID must be greater than or equal to 1";
-    public static final String USERNAME_SIZE = "Username must be between 1 and 20 characters";
+    public static final String USERNAME_SIZE =
+            "Username must be between 1 and " + User.MAX_USERNAME_LENGTH + " characters";
 
-    public static final String NICKNAME_SIZE = "Nickname must be between 1 and 20 characters";
+    public static final String NICKNAME_SIZE =
+            "Nickname must be between 1 and " + User.MAX_NICKNAME_LENGTH + " characters";
     public static final String USERNAME_NOT_BLANK = "username must not be blank";
     public static final String NICKNAME_NOT_BLANK = "nickname must not be blank";
 

--- a/src/main/java/com/nexters/teamace/user/application/CreateUserCommand.java
+++ b/src/main/java/com/nexters/teamace/user/application/CreateUserCommand.java
@@ -2,6 +2,7 @@ package com.nexters.teamace.user.application;
 
 import static com.nexters.teamace.common.exception.ValidationErrorMessage.*;
 
+import com.nexters.teamace.user.domain.User;
 import org.springframework.util.StringUtils;
 
 public record CreateUserCommand(String username, String nickname) {
@@ -10,7 +11,7 @@ public record CreateUserCommand(String username, String nickname) {
             if (!StringUtils.hasText(username)) {
                 throw new IllegalArgumentException(USERNAME_NOT_BLANK);
             }
-            if (username.length() > 20) {
+            if (username.length() > User.MAX_USERNAME_LENGTH) {
                 throw new IllegalArgumentException(USERNAME_SIZE);
             }
         }
@@ -18,7 +19,7 @@ public record CreateUserCommand(String username, String nickname) {
             if (!StringUtils.hasText(nickname)) {
                 throw new IllegalArgumentException(NICKNAME_NOT_BLANK);
             }
-            if (nickname.length() > 20) {
+            if (nickname.length() > User.MAX_NICKNAME_LENGTH) {
                 throw new IllegalArgumentException(NICKNAME_SIZE);
             }
         }

--- a/src/main/java/com/nexters/teamace/user/domain/User.java
+++ b/src/main/java/com/nexters/teamace/user/domain/User.java
@@ -9,6 +9,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = PROTECTED)
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class User {
+    public static final int MAX_USERNAME_LENGTH = 50;
+    public static final int MAX_NICKNAME_LENGTH = 20;
 
     @Getter @EqualsAndHashCode.Include private Long id;
     @Getter private String username;

--- a/src/test/java/com/nexters/teamace/auth/application/LoginCommandTest.java
+++ b/src/test/java/com/nexters/teamace/auth/application/LoginCommandTest.java
@@ -50,17 +50,17 @@ class LoginCommandTest {
     }
 
     @Nested
-    @DisplayName("20자보다 긴 사용자명으로 생성할 때")
+    @DisplayName("50자보다 긴 사용자명으로 생성할 때")
     class Context_when_creating_with_username_longer_than_20_characters {
 
         @Test
         @DisplayName("IllegalArgumentException을 던진다")
         void it_throws_IllegalArgumentException() {
-            final String longUsername = "a".repeat(21);
+            final String longUsername = "a".repeat(51);
 
             thenThrownBy(() -> new LoginCommand(longUsername))
                     .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("Username must be between 1 and 20 characters");
+                    .hasMessage("Username must be between 1 and 50 characters");
         }
     }
 }

--- a/src/test/java/com/nexters/teamace/auth/application/SignupCommandTest.java
+++ b/src/test/java/com/nexters/teamace/auth/application/SignupCommandTest.java
@@ -51,17 +51,17 @@ class SignupCommandTest {
     }
 
     @Nested
-    @DisplayName("20자보다 긴 사용자명으로 생성할 때")
+    @DisplayName("50자보다 긴 사용자명으로 생성할 때")
     class Context_when_creating_with_username_longer_than_20_characters {
 
         @Test
         @DisplayName("IllegalArgumentException을 던진다")
         void it_throws_IllegalArgumentException() {
-            final String longUsername = "a".repeat(21);
+            final String longUsername = "a".repeat(51);
 
             thenThrownBy(() -> new SignupCommand(longUsername, "Valid User"))
                     .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("Username must be between 1 and 20 characters");
+                    .hasMessage("Username must be between 1 and 50 characters");
         }
     }
 

--- a/src/test/java/com/nexters/teamace/user/application/CreateUserCommandTest.java
+++ b/src/test/java/com/nexters/teamace/user/application/CreateUserCommandTest.java
@@ -66,17 +66,17 @@ class CreateUserCommandTest {
     }
 
     @Nested
-    @DisplayName("20자보다 긴 사용자명으로 생성할 때")
+    @DisplayName("50자보다 긴 사용자명으로 생성할 때")
     class Context_when_creating_with_username_longer_than_20_characters {
 
         @Test
         @DisplayName("IllegalArgumentException을 던진다")
         void it_throws_IllegalArgumentException() {
-            final String longUsername = "a".repeat(21);
+            final String longUsername = "a".repeat(51);
 
             thenThrownBy(() -> new CreateUserCommand(longUsername, "Valid User"))
                     .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("Username must be between 1 and 20 characters");
+                    .hasMessage("Username must be between 1 and 50 characters");
         }
     }
 


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feat(#133): canvas 구현~ -->
<!-- 💡 브랜치 이름이 feature/5, fix/123 등인 경우 숫자가 이슈 번호입니다 -->
<!-- "여기에 작성하세요", "(필수 X)"는 지우고 작성하세요 🙏🏻 -->

## 📌 관련 이슈
<!-- 이슈 번호를 #숫자 형식으로 작성하면 자동으로 연결됩니다 -->
<!-- ex) #5, closes #5, fixes #5 -->
#10 

## 📝 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
실제 deviceCode가 길어서 username 길이 제한 상향 조정

## ✅ 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
- [x] username 길이 제한 상향 조정

## 💭 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->
하드코딩 되어있어서 하나로 뺐는데 어디 둘까 하다가 일단 도메인으로 뺐어욤


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 사용자명 최대 길이를 20자에서 50자로 확장했습니다. 회원가입, 로그인, 사용자 생성 전반에 동일하게 적용됩니다.
  - 오류 메시지가 현재 최대 길이를 동적으로 반영해 안내 정확성이 향상되었습니다.
- Refactor
  - 길이 검증 기준을 단일 상수로 일원화하여 검증·메시지의 일관성을 높였습니다.
- Tests
  - 변경된 최대 길이에 맞춰 테스트 데이터와 기대 메시지를 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->